### PR TITLE
Fix alias bug for docker

### DIFF
--- a/new_cronfig/.alias_bashrc
+++ b/new_cronfig/.alias_bashrc
@@ -2,7 +2,8 @@
 alias drad='docker rm '
 alias drld='docker ps -a -q -f status=exited'
 alias dclean='docker system prune -f'
-alias dstopall='docker stop 96f6721f41a0'
+# Stop all running Docker containers
+alias dstopall='docker stop $(docker ps -q)'
 alias dps='docker ps'
 alias ..='cd .. && ls'
 alias ...='cd ../.. && ls'
@@ -43,5 +44,6 @@ alias tfa='terraform apply -auto-approve'
 alias tfi='terraform init'
 alias tfp='terraform plan'
 alias tfv='terraform validate'
-alias upconfig='cp ~/.alias_bashrc ~/.func_bashrc ~/projects/cronfig/new_cronfig/ && cd ~/projects/cronfig/ && git add . && git commit -m "updated config files" || echo "Nothing to commit" && git push'
+# Sync local config files back to the Cronfig repository
+alias upconfig='cp ~/.alias_bashrc ~/.func_bashrc ~/projects/cronfig/new_cronfig/ && cd ~/projects/cronfig/ && git add . && git commit -m "updated config files" && git push || echo "Nothing to commit"'
 #####


### PR DESCRIPTION
## Summary
- fix the `dstopall` alias to actually stop all running containers
- fix `upconfig` alias to push only after a successful commit

## Testing
- `bash -n new_cronfig/.alias_bashrc`
- `bash -n new_cronfig/.func_bashrc`
- `bash -n cronfig_init.sh`


------
https://chatgpt.com/codex/tasks/task_e_6856ab497ef0832a94898987b1ee5f4b